### PR TITLE
Disable TCP Timestamps

### DIFF
--- a/defaults/main/sysctl.yml
+++ b/defaults/main/sysctl.yml
@@ -27,6 +27,7 @@ ipv4_sysctl_settings:
   net.ipv4.tcp_syn_retries: 5
   net.ipv4.tcp_synack_retries: 2
   net.ipv4.tcp_syncookies: 1
+  net.ipv4.tcp_timestamps: 0
 
 ipv6_sysctl_settings:
   net.ipv6.conf.all.accept_ra: 0


### PR DESCRIPTION
the TCP timestamp response to approximate the remote host's uptime and aid in further attacks. Additionally, some operating systems can be fingerprinted based on the behavior of their TCP time stamps.